### PR TITLE
Improve hardware tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,21 +394,29 @@ if(CATKIN_ENABLE_TESTING)
   ##  Hardware-Tests  ##
   ######################
 
-  # build this using catkin_make -DENABLE_HARDWARE_TESTING=ON
+  # See ./hwtest_readme.md for details on the hardware tests.
   if(ENABLE_HARDWARE_TESTING)
-    find_package(rosbag REQUIRED)
 
-    add_rostest_gtest(hwtest_scan_compare
-        test/hw_tests/hwtest_scan_compare.test
-        test/hw_tests/hwtest_scan_compare.cpp
-        standalone/src/laserscan.cpp
-    )
-    target_link_libraries(hwtest_scan_compare
-      ${catkin_LIBRARIES}
-      ${pilz_testutils_LIBRARIES}
-      ${rosbag_LIBRARIES}
-      fmt::fmt
-    )
+
+    # This test is intended to be run on in a dedicated environment with a prerecorded reference scan
+    # and thus needs to be enabled seperately.
+    if(ENABLE_HARDWARE_TESTING_WITH_REFERENCE_SCAN)
+      find_package(rosbag REQUIRED)
+
+      add_rostest_gtest(hwtest_scan_compare
+          test/hw_tests/hwtest_scan_compare.test
+          test/hw_tests/hwtest_scan_compare.cpp
+          standalone/src/laserscan.cpp
+      )
+      target_link_libraries(hwtest_scan_compare
+        ${catkin_LIBRARIES}
+        ${pilz_testutils_LIBRARIES}
+        ${rosbag_LIBRARIES}
+        fmt::fmt
+      )
+    endif()
+
+    add_rostest(test/hw_tests/hwtest_publish.test)
   endif()
 
 

--- a/test/hw_tests/hwtest_publish.test
+++ b/test/hw_tests/hwtest_publish.test
@@ -26,9 +26,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     <arg name="rviz" value="False" />
   </include>
 
-  <test test-name="scan_compare" pkg="psen_scan_v2" type="hwtest_scan_compare" time-limit="$(eval test_duration + 10)">
-    <param name="testfile" value="$(env HW_TEST_SCAN_COMPARE_TESTFILE)"/>
-    <param name="test_duration" value="$(arg test_duration)"/>
+  <test name="publishtest"
+        test-name="publishtest"
+        pkg="rostest" type="publishtest">
+    <rosparam>
+      topics:
+        - name: laser_scanner/scan
+          timeout: 10
+          negative: False
+    </rosparam>
   </test>
-
 </launch>

--- a/test/hw_tests/hwtest_readme.md
+++ b/test/hw_tests/hwtest_readme.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Hardware Tests with psen_scan_v2
 
-## Build
+## Build and run using `catkin_make`
 To build the hardware tests execute
 ```
 catkin_make
@@ -25,7 +25,40 @@ catkin_make tests -DENABLE_HARDWARE_TESTING=ON
 ```
 in your catkin workspace.
 
-## Setup the reference scan
+## Build and run using `catkin`
+To build and run the hardware tests using `catkin` run something like
+```
+SENSOR_IP=192.168.0.100 catkin run_tests --cmake-args -DENABLE_HARDWARE_TESTING=ON && catkin_test_results
+```
+## Build and run using `industrial_ci`
+Setup `industrial_ci` to run locally using [this instructions](https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#simplest-way-to-run-locally).
+Then run
+```
+rosrun industrial_ci run_ci ROS_DISTRO=noetic ROS_REPO=main \
+CMAKE_ARGS="-DENABLE_HARDWARE_TESTING=ON" DOCKER_RUN_OPTS="--env \
+HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100 -p 55115:55115/udp -p 55116:55116/udp"
+```
+note that you especially need to setup the `HOST_IP` to be the IP of your actually system
+in order to receive the data inside the docker container used by industrial_ci.
+
+### With a custom ROOT_CA and apt proxy
+If you need to use a custom ROOT_CA and have a apt-proxy the command for running `industrial_ci` locally extends to
+```
+rosrun industrial_ci run_ci ROS_DISTRO=noetic ROS_REPO=main \
+CMAKE_ARGS="-DENABLE_HARDWARE_TESTING=ON" \
+DOCKER_RUN_OPTS="--env HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100 \
+-p 55115:55115/udp -p 55116:55116/udp \
+-v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro" \
+APT_PROXY=http://172.20.20.104:3142
+
+```
+
+## Run `hwtest_scan_compare`
+The `hwtest_scan_compare` compares scanner data to a set of prerecorded data in order to detect unwanted changes in the data itself (shifts, flips, ...).
+
+### Build the test
+Same as above however **additionally** `-ENABLE_HARDWARE_TESTING_WITH_REFERENCE_SCAN=ON` needs to be defined at compile time. At runtime the reference file needs to be set within the environment variable `HW_TEST_SCAN_COMPARE_TESTFILE`, for details see the instructions below.
+### Setup the reference scan
 This step is only needed if the setup of the scanner or something within its environment changed.
 
 First startup the scanner
@@ -40,7 +73,7 @@ export HW_TEST_SCAN_COMPARE_TESTFILE=<your/desired/path/file.bag>
 rosbag record -a -O $HW_TEST_SCAN_COMPARE_TESTFILE --duration 10
 ```
 
-## Run
+### Run using `rostest`
 To run the hardware tests execute
 ```
 export HW_TEST_SCAN_COMPARE_TESTFILE=<path/to/reference/file.bag>


### PR DESCRIPTION
* Separate the publish tests to be executable separately
* Introduce CMake-flag ENABLE_HARDWARE_TESTING_WITH_REFERENCE_SCAN
* Add more instructions to hwtest_readme.md
* Hardwaretests take the env variables HOST_IP and SENSOR_IP into
account which is needed to be able to run the tests from within
industrial_ci

* [ ] Perform hardware tests